### PR TITLE
feat: Add typing cursor effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ cmdRef.current?.clear();    // Clear
 | `timerType` | `'setTimeout' \| 'requestAnimationFrame'` | `'setTimeout'` | Timer type |
 | `showCursor` | `boolean` | `false` | Whether to show cursor |
 | `cursor` | `React.ReactNode` | `"\|"` | Cursor content |
+| `showCursorOnPause` | `boolean` | `true` | Whether to show cursor when paused |
 | `disableTyping` | `boolean` | `false` | Disable typing animation |
 | `autoStartTyping` | `boolean` | `true` | Auto start typing |
 | `onStart` | `(data) => void` | - | Typing start callback |

--- a/README.zh.md
+++ b/README.zh.md
@@ -157,6 +157,7 @@ cmdRef.current?.clear();    // 清除
 | `timerType` | `'setTimeout' \| 'requestAnimationFrame'` | `'setTimeout'` | 定时器类型 |
 | `showCursor` | `boolean` | `false` | 是否显示光标 |
 | `cursor` | `React.ReactNode` | `"\|"` | 光标内容 |
+| `showCursorOnPause` | `boolean` | `true` | 暂停时是否显示光标 |
 | `disableTyping` | `boolean` | `false` | 禁用打字动画 |
 | `autoStartTyping` | `boolean` | `true` | 是否自动开始 |
 | `onStart` | `(data) => void` | - | 打字开始回调 |

--- a/example/basic/index.tsx
+++ b/example/basic/index.tsx
@@ -81,19 +81,28 @@ const BasicDemo: React.FC = () => {
       <div className="ds-message-actions">
         <div>
           <button onClick={onReset}>重置</button>
-          <button disabled={isStop} onClick={onStop}>
+          {/* <button disabled={isStop} onClick={onStop}>
             停止
           </button>
           <button disabled={!isStop} onClick={onResume}>
             继续
-          </button>
+          </button> */}
+          {
+            isStop ? <button disabled={!isStop} onClick={onResume}>
+              继续
+            </button> : <button disabled={isStop} onClick={onStop}>
+              停止
+            </button>
+          }
           <button onClick={() => markdownRef.current.restart()}>重新开始</button>
           <span style={{ marginLeft: 30 }}>React 19有哪些新特性2</span>
         </div>
       </div>
       <div className="ds-message-box" ref={messageDivRef} onScroll={onScroll}>
         <div className="ds-message-list">
-         example
+          <Markdown interval={15} ref={markdownRef} onTypedChar={throttleOnTypedChar} timerType={timerType} autoStartTyping={true} showCursor>
+            {json.content}
+          </Markdown>
         </div>
       </div>
     </>

--- a/example/katex/index.tsx
+++ b/example/katex/index.tsx
@@ -128,6 +128,7 @@ const App: React.FC = () => {
             math={{ splitSymbol: 'bracket' }}
             disableTyping={disableTyping}
             autoStartTyping={false}
+            showCursor
             reactMarkdownProps={mathOpen ? { remarkPlugins: [remarkMath], rehypePlugins: [rehypeKatex] } : undefined}
           >
             {dataJson.content}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-markdown-typer",
   "private": false,
-  "version": "1.0.3",
+  "version": "1.0.4-beta.0",
   "main": "./es/index.js",
   "type": "module",
   "license": "MIT",
@@ -115,6 +115,6 @@
     "react-markdown"
   ],
   "publishConfig": {
-    "tag": "latest"
+    "tag": "beta"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-markdown-typer",
   "private": false,
-  "version": "1.0.4-beta.0",
+  "version": "1.0.4-beta.1",
   "main": "./es/index.js",
   "type": "module",
   "license": "MIT",

--- a/src/defined.ts
+++ b/src/defined.ts
@@ -87,6 +87,9 @@ export interface MarkdownTyperBaseProps {
 
   /** Custom cursor, can be string or ReactNode, default is '|' */
   cursor?: React.ReactNode;
+
+  /** Whether to show cursor when typing is paused, default is true */
+  showCursorOnPause?: boolean;
 }
 
 export interface MarkdownTyperProps extends MarkdownTyperBaseProps {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-markdown-typer": "^0.0.2",
+        "react-markdown-typer": "1.0.4-beta.0",
         "react-syntax-highlighter": "^15.6.1",
         "remark-gfm": "^4.0.1"
       },
@@ -3078,9 +3078,9 @@
       }
     },
     "node_modules/react-markdown-typer": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/react-markdown-typer/-/react-markdown-typer-0.0.2.tgz",
-      "integrity": "sha512-TlM+totNlvvTEusvQOBAfBB8BVgyR7QlmqEvomwcCikvGczUpqzjPfkkrqaupd+7ZRMccudTcEqegMm5PS0O0A==",
+      "version": "1.0.4-beta.0",
+      "resolved": "https://registry.npmjs.org/react-markdown-typer/-/react-markdown-typer-1.0.4-beta.0.tgz",
+      "integrity": "sha512-JJSyaagG0dwWJZNEkiO7p0UdYAOTvDdnQoJQ6+KqLyo3ibxWm7TE1Q0Eo7kyn3FaYsrixbzI8vB8zsWH7cgWsw==",
       "license": "MIT",
       "dependencies": {
         "react-markdown": "^10.1.0"

--- a/website/package.json
+++ b/website/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-markdown-typer": "^0.0.2",
+    "react-markdown-typer": "1.0.4-beta.0",
     "react-syntax-highlighter": "^15.6.1",
     "remark-gfm": "^4.0.1"
   },

--- a/website/src/components/Demos/BasicUsageDemo/index.tsx
+++ b/website/src/components/Demos/BasicUsageDemo/index.tsx
@@ -83,6 +83,7 @@ const BasicUsageDemo: React.FC<DemoProps> = ({ markdown }) => {
       <ReactMarkdownTyper
         ref={markdownRef}
         interval={25}
+        showCursor
         reactMarkdownProps={{
           remarkPlugins: [remarkGfm],
         }}


### PR DESCRIPTION
## Overview

This MR adds a typing cursor effect feature with intelligent placement using rehype plugins, and includes pause control configuration.

## New Features

### Cursor Effect
- ✅ Display cursor during typing animation
- ✅ Support string cursor (e.g., `"|"`, `"▋"`)
- ✅ Support custom ReactNode cursor (full control over styles and animations)
- ✅ Automatic cursor rendering via rehype plugin, zero configuration
- ✅ Cursor always follows text, no conflicts with markdown syntax

### New Props
showCursor?: boolean;           // Whether to show cursor (default: false)
cursor?: React.ReactNode;       // Cursor content (default: "|")
showCursorOnPause?: boolean;    // Show cursor when paused (default: true)## Code Improvements

### Structure Optimization
- 📁 Added `src/plugins/rehypeCursor.ts` - Rehype plugin for cursor handling
- 📁 Added `src/components/CursorSpan.tsx` - Cursor span component
- 🔄 Optimized `useTypingTask` hook, exports `isTypingRef` for cursor usage

### Bug Fixes
- 🐛 Fixed cursor placeholder conflict with markdown syntax (using zero-width space marker)
- 🐛 Fixed cursor flickering issue (using ref instead of state to avoid timing issues)
- 🐛 Fixed cursor placeholder showing when paused/stopped (added updateCount dependency)
- 🐛 Fixed cursor rendering outside code blocks (intelligent placement via rehype plugin)

## Implementation Details

### Rehype Plugin Approach
- Uses zero-width space marker `\u200B__MDTYPER_CURSOR__\u200B` to avoid markdown conflicts
- Automatically processes cursor placeholder in HTML AST
- Handles code blocks intelligently to ensure cursor stays inside

### Cursor Display Logic
- Shows during typing: `isTyping = true`
- Shows when paused: `isPaused = true && showCursorOnPause = true`
- Hides when: typing completed or `showCursorOnPause = false`

## Documentation

- ✂️ Streamlined README (from 876 lines to ~380 lines)
- ✍️ Optimized core features copy
- 🌐 Synchronized Chinese and English README
- 🎨 Removed excessive icons for cleaner look

## Usage Examples

// Basic usage
<MarkdownTyperCMD 
  showCursor={true}
  cursor="|"
/>

// Custom ReactNode cursor
<MarkdownTyperCMD 
  showCursor={true}
  cursor={<AnimatedCursor />}
/>

// Hide cursor when paused
<MarkdownTyperCMD 
  showCursor={true}
  showCursorOnPause={false}
/>## Testing

- ✅ Cursor displays correctly during typing
- ✅ Cursor shows/hides based on pause configuration
- ✅ Cursor stays inside code blocks
- ✅ No placeholder text leakage
- ✅ Compatible with other rehype plugins

## Backward Compatibility

- ✅ Fully backward compatible, default `showCursor={false}`
- ✅ No impact on existing functionality
- ✅ All existing APIs remain unchanged

## Related Files

- `src/defined.ts` - Type definitions
- `src/MarkdownTyperCMD/index.tsx` - Main component implementation
- `src/plugins/rehypeCursor.ts` - Rehype plugin
- `src/components/CursorSpan.tsx` - Cursor component
- `src/hooks/useTypingTask.ts` - Hook optimization
- `README.md` / `README.zh.md` - Documentation updates