### PR TITLE
add experimentalIncrementalRender mode for stable/tail split rendering

### DIFF
--- a/example/basic/index.tsx
+++ b/example/basic/index.tsx
@@ -72,7 +72,7 @@ const BasicDemo: React.FC = () => {
     }, 50);
   }, []);
 
-  const interval = 8;
+  const interval = 10;
   const flag = true;
   const timerType = flag ? 'requestAnimationFrame' : 'setTimeout';
 
@@ -100,7 +100,7 @@ const BasicDemo: React.FC = () => {
       </div>
       <div className="ds-message-box" ref={messageDivRef} onScroll={onScroll}>
         <div className="ds-message-list">
-          <Markdown interval={15} ref={markdownRef} onTypedChar={throttleOnTypedChar} timerType={timerType} autoStartTyping={true} showCursor>
+          <Markdown interval={interval} ref={markdownRef} onTypedChar={throttleOnTypedChar} timerType={timerType} autoStartTyping={true} showCursor experimentalIncrementalRender>
             {json.content}
           </Markdown>
         </div>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,20 @@
+export default {
+  transform: {
+    '^.+\\.(js|jsx|ts|tsx|mjs)$': [
+      'babel-jest',
+      {
+        presets: ['@babel/preset-env', ['@babel/preset-react', { runtime: 'automatic' }], '@babel/preset-typescript'],
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node', 'mjs'],
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+  testMatch: ['<rootDir>/test/**/*.test.(ts|tsx|js|jsx)'],
+  // Many markdown ecosystem packages ship ESM-only.
+  // Transform all dependencies in tests to avoid brittle allow-lists.
+  transformIgnorePatterns: [],
+};

--- a/src/MarkdownTyper/index.tsx
+++ b/src/MarkdownTyper/index.tsx
@@ -7,9 +7,19 @@ interface MarkdownTyperInnerProps extends MarkdownTyperProps {
   markdownRef: React.ForwardedRef<MarkdownTyperRef>;
 }
 
+function getLongestCommonPrefixLength(a: string, b: string): number {
+  const minLen = Math.min(a.length, b.length);
+  let i = 0;
+  while (i < minLen && a[i] === b[i]) {
+    i += 1;
+  }
+  return i;
+}
+
 const MarkdownTyperInner: React.FC<MarkdownTyperInnerProps> = ({ children: _children = '', markdownRef, ...rest }) => {
   const cmdRef = useRef<MarkdownTyperCMDRef>(null!);
   const prefixRef = useRef('');
+  const { experimentalIncrementalRender = false } = rest;
   const content = useMemo(() => {
     if (typeof _children === 'string') {
       return _children;
@@ -29,14 +39,21 @@ const MarkdownTyperInner: React.FC<MarkdownTyperInnerProps> = ({ children: _chil
         if (content.startsWith(prefixRef.current)) {
           newContent = content.slice(prefixRef.current.length);
         } else {
-          newContent = content;
-          cmdRef.current.clear();
+          if (experimentalIncrementalRender) {
+            const lcpLen = getLongestCommonPrefixLength(prefixRef.current, content);
+            const sharedPrefix = content.slice(0, lcpLen);
+            cmdRef.current.setContent(sharedPrefix);
+            newContent = content.slice(lcpLen);
+          } else {
+            newContent = content;
+            cmdRef.current.clear();
+          }
         }
       }
       cmdRef.current.push(newContent);
       prefixRef.current = content;
     }
-  }, [content]);
+  }, [content, experimentalIncrementalRender]);
 
   useImperativeHandle(markdownRef, () => ({
     stop: () => {

--- a/src/MarkdownTyper/index.tsx
+++ b/src/MarkdownTyper/index.tsx
@@ -36,9 +36,6 @@ const MarkdownTyperInner: React.FC<MarkdownTyperInnerProps> = ({ children: _chil
       cmdRef.current.push(newContent);
       prefixRef.current = content;
     }
-    return () => {
-      console.log('unmount');
-    };
   }, [content]);
 
   useImperativeHandle(markdownRef, () => ({

--- a/src/MarkdownTyperCMD/index.tsx
+++ b/src/MarkdownTyperCMD/index.tsx
@@ -113,7 +113,7 @@ const MarkdownTyperCMD = forwardRef<MarkdownTyperCMDRef, MarkdownTyperCMDProps>(
       wholeContentRef.current.length += content.length;
       triggerUpdate();
       onEnd?.({
-        str: content,
+        str: wholeContentRef.current.content,
         manual: false,
       });
     };

--- a/src/MarkdownTyperCMD/index.tsx
+++ b/src/MarkdownTyperCMD/index.tsx
@@ -7,9 +7,187 @@ import { splitGraphemes } from '../utils/grapheme';
 import { createRehypeCursorPlugin } from '../plugins/rehypeCursor';
 import { CursorSpan } from '../components/CursorSpan';
 
+const CURSOR_MARKER = '\u200B__MDTYPER_CURSOR__\u200B';
+const DEFAULT_INCREMENTAL_FLUSH_THRESHOLD = 1200;
+
+interface IncrementalContext {
+  inFenceCode: boolean;
+  inMathBlock: boolean;
+  inContainerBlock: boolean;
+  inTable: boolean;
+  possibleTableHeader: boolean;
+  previousNonEmptyLine: string;
+  lineBuffer: string;
+}
+
+function createInitialIncrementalContext(): IncrementalContext {
+  return {
+    inFenceCode: false,
+    inMathBlock: false,
+    inContainerBlock: false,
+    inTable: false,
+    possibleTableHeader: false,
+    previousNonEmptyLine: '',
+    lineBuffer: '',
+  };
+}
+
+function isFenceLine(line: string): boolean {
+  return /^\s{0,3}(```|~~~)/.test(line);
+}
+
+function isMathBlockDelimiter(line: string): boolean {
+  return /^\s*\$\$\s*$/.test(line);
+}
+
+function isContainerLine(line: string): boolean {
+  return /^\s{0,3}(>|[-+*]\s+|\d+\.\s+)/.test(line);
+}
+
+function isContainerContinuationLine(line: string): boolean {
+  return /^\s{2,}\S/.test(line);
+}
+
+function isAtxHeadingLine(line: string): boolean {
+  return /^\s{0,3}#{1,6}(?:\s+|$)/.test(line);
+}
+
+function isThematicBreakLine(line: string): boolean {
+  return /^\s{0,3}([-*_]\s*){3,}$/.test(line);
+}
+
+function isSetextUnderlineLine(line: string): boolean {
+  return /^\s{0,3}(=+|-+)\s*$/.test(line);
+}
+
+function isTableSeparatorLine(line: string): boolean {
+  return /^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$/.test(line);
+}
+
+function looksLikeTableHeaderLine(line: string): boolean {
+  return line.includes('|') && !isTableSeparatorLine(line);
+}
+
+function isReferenceDefinitionLine(line: string): boolean {
+  return /^\s{0,3}\[[^\]]+\]:\s+\S+/.test(line);
+}
+
+function shouldFlushAtLineBoundary(line: string, context: IncrementalContext, isSetextHeading: boolean): boolean {
+  if (context.inFenceCode || context.inMathBlock || context.inContainerBlock) {
+    return false;
+  }
+
+  if (context.inTable) {
+    return false;
+  }
+
+  if (/^\s*$/.test(line)) {
+    return true;
+  }
+
+  if (isAtxHeadingLine(line) || isThematicBreakLine(line) || isSetextHeading || isReferenceDefinitionLine(line)) {
+    return true;
+  }
+
+  return false;
+}
+
+function shouldForceFlushBySize(context: IncrementalContext, tail: string, threshold: number): boolean {
+  if (context.inFenceCode || context.inMathBlock) {
+    return tail.length >= threshold * 2;
+  }
+  return tail.length >= threshold;
+}
+
+function buildIncrementalContextFromContent(content: string): IncrementalContext {
+  const context = createInitialIncrementalContext();
+  for (const char of splitGraphemes(content)) {
+    context.lineBuffer += char;
+    if (char !== '\n') {
+      continue;
+    }
+
+    const line = context.lineBuffer.slice(0, -1);
+    context.lineBuffer = '';
+    processCompletedLine(line, context);
+  }
+  return context;
+}
+
+function processCompletedLine(line: string, context: IncrementalContext): boolean {
+  const isBlank = /^\s*$/.test(line);
+
+  if (!context.inFenceCode && !context.inMathBlock && isFenceLine(line)) {
+    context.inFenceCode = true;
+  } else if (context.inFenceCode && isFenceLine(line)) {
+    context.inFenceCode = false;
+  } else if (!context.inFenceCode && isMathBlockDelimiter(line)) {
+    context.inMathBlock = !context.inMathBlock;
+  }
+
+  const wasTableHeader = context.possibleTableHeader;
+  if (context.inFenceCode || context.inMathBlock) {
+    context.inContainerBlock = false;
+    context.inTable = false;
+    context.possibleTableHeader = false;
+  } else if (isBlank) {
+    context.inContainerBlock = false;
+    context.inTable = false;
+    context.possibleTableHeader = false;
+  } else {
+    if (context.inTable) {
+      if (!line.includes('|')) {
+        context.inTable = false;
+      }
+    } else if (wasTableHeader && isTableSeparatorLine(line)) {
+      context.inTable = true;
+    }
+    context.possibleTableHeader = looksLikeTableHeaderLine(line);
+
+    if (isContainerLine(line)) {
+      context.inContainerBlock = true;
+    } else if (context.inContainerBlock && isContainerContinuationLine(line)) {
+      context.inContainerBlock = true;
+    } else {
+      context.inContainerBlock = false;
+    }
+  }
+
+  const isSetextHeading = isSetextUnderlineLine(line)
+    && !context.inFenceCode
+    && !context.inMathBlock
+    && !context.inTable
+    && !context.inContainerBlock
+    && context.previousNonEmptyLine.length > 0;
+
+  const shouldFlush = shouldFlushAtLineBoundary(line, context, isSetextHeading);
+
+  if (!isBlank) {
+    context.previousNonEmptyLine = line;
+  }
+
+  return shouldFlush;
+}
+
 const MarkdownTyperCMD = forwardRef<MarkdownTyperCMDRef, MarkdownTyperCMDProps>(
   (
-    { interval = 30, onEnd, onStart, onTypedChar, onBeforeTypedChar, timerType = 'setTimeout', reactMarkdownProps, disableTyping = false, autoStartTyping = true, customConvertMarkdownString, showCursor = false, cursor = '|', showCursorOnPause = true },
+    {
+      interval = 30,
+      onEnd,
+      onStart,
+      onTypedChar,
+      onBeforeTypedChar,
+      timerType = 'setTimeout',
+      reactMarkdownProps,
+      disableTyping = false,
+      autoStartTyping = true,
+      customConvertMarkdownString,
+      showCursor = false,
+      cursor = '|',
+      showCursorOnPause = true,
+      experimentalIncrementalRender = false,
+      incrementalFlushThreshold = DEFAULT_INCREMENTAL_FLUSH_THRESHOLD,
+    },
     ref,
   ) => {
     /** Whether to automatically start typing animation, changes after initialization will not take effect */
@@ -35,9 +213,63 @@ const MarkdownTyperCMD = forwardRef<MarkdownTyperCMDRef, MarkdownTyperCMDProps>(
       prevLength: 0,
     });
 
+    /** Incremental render buffers */
+    const stableContentRef = useRef('');
+    const tailContentRef = useRef('');
+    const incrementalContextRef = useRef<IncrementalContext>(createInitialIncrementalContext());
+
     const [updateCount, setUpdate] = useState(0);
     const triggerUpdate = () => {
       setUpdate((prev) => prev + 1);
+    };
+
+    const appendToIncrementalBuffers = (content: string) => {
+      if (!experimentalIncrementalRender || content.length === 0) {
+        return;
+      }
+
+      tailContentRef.current += content;
+      const context = incrementalContextRef.current;
+
+      const chars = splitGraphemes(content);
+      for (const char of chars) {
+        context.lineBuffer += char;
+        if (char !== '\n') {
+          continue;
+        }
+
+        const line = context.lineBuffer.slice(0, -1);
+        context.lineBuffer = '';
+        if (processCompletedLine(line, context)) {
+          stableContentRef.current += tailContentRef.current;
+          tailContentRef.current = '';
+          break;
+        }
+      }
+
+      const threshold = Math.max(64, incrementalFlushThreshold);
+      if (tailContentRef.current.length > 0 && shouldForceFlushBySize(context, tailContentRef.current, threshold)) {
+        stableContentRef.current += tailContentRef.current;
+        tailContentRef.current = '';
+      }
+    };
+
+    const setIncrementalContent = (content: string) => {
+      if (!experimentalIncrementalRender) {
+        return;
+      }
+      stableContentRef.current = content;
+      tailContentRef.current = '';
+      incrementalContextRef.current = buildIncrementalContextFromContent(content);
+    };
+
+    const resetWholeContent = () => {
+      wholeContentRef.current.content = '';
+      wholeContentRef.current.length = 0;
+      wholeContentRef.current.prevLength = 0;
+      stableContentRef.current = '';
+      tailContentRef.current = '';
+      incrementalContextRef.current = createInitialIncrementalContext();
     };
 
     /**
@@ -50,13 +282,8 @@ const MarkdownTyperCMD = forwardRef<MarkdownTyperCMDRef, MarkdownTyperCMDProps>(
       wholeContentRef.current.prevLength = wholeContentRef.current.length;
       wholeContentRef.current.content += char.content;
       wholeContentRef.current.length += char.content.length;
+      appendToIncrementalBuffers(char.content);
       triggerUpdate();
-    };
-
-    const resetWholeContent = () => {
-      wholeContentRef.current.content = '';
-      wholeContentRef.current.length = 0;
-      wholeContentRef.current.prevLength = 0;
     };
 
     // Use new typing task hook
@@ -111,6 +338,11 @@ const MarkdownTyperCMD = forwardRef<MarkdownTyperCMDRef, MarkdownTyperCMDProps>(
       // Record length before typing
       wholeContentRef.current.prevLength = wholeContentRef.current.length;
       wholeContentRef.current.length += content.length;
+
+      if (experimentalIncrementalRender) {
+        setIncrementalContent(wholeContentRef.current.content);
+      }
+
       triggerUpdate();
       onEnd?.({
         str: wholeContentRef.current.content,
@@ -122,7 +354,6 @@ const MarkdownTyperCMD = forwardRef<MarkdownTyperCMDRef, MarkdownTyperCMDProps>(
       /**
        * Add content
        * @param content Content {string}
-       * @param answerType Answer type {AnswerType}
        */
       push: (content: string) => {
         if (disableTyping) {
@@ -130,6 +361,26 @@ const MarkdownTyperCMD = forwardRef<MarkdownTyperCMDRef, MarkdownTyperCMDProps>(
           return;
         }
         processHasTypingPush(content);
+      },
+      /** Replace content immediately without typing animation */
+      setContent: (content: string) => {
+        typingTask.clear();
+        typingTask.typedIsManualStopRef.current = false;
+        charsRef.current = [];
+        isWholeTypedEndRef.current = false;
+
+        resetWholeContent();
+        wholeContentRef.current.content = content;
+        wholeContentRef.current.prevLength = content.length;
+        wholeContentRef.current.length = content.length;
+
+        if (experimentalIncrementalRender) {
+          setIncrementalContent(content);
+        }
+
+        charIndexRef.current = splitGraphemes(content).length;
+        isStartedTypingRef.current = content.length > 0;
+        triggerUpdate();
       },
       /**
        * Clear typing task
@@ -185,62 +436,18 @@ const MarkdownTyperCMD = forwardRef<MarkdownTyperCMDRef, MarkdownTyperCMDProps>(
       },
     }));
 
-    const markdownString = useMemo(() => {
-      return customConvertMarkdownString?.(wholeContentRef.current.content) || wholeContentRef.current.content;
-    }, [wholeContentRef.current.content, customConvertMarkdownString]);
-
-    // Build display string with cursor placeholder
-    // Include updateCount to ensure re-calculation when typing state changes
-    const displayString = useMemo(() => {
-      // Show cursor when:
-      // 1. Currently typing (isTypingRef.current = true), or
-      // 2. Paused and showCursorOnPause is true and has pending content
-      const isTyping = typingTask.isTypingRef.current;
-      const hasPendingContent = charsRef.current.length > 0;
-      const isPaused = !isTyping && hasPendingContent;
-      const shouldShowCursorNow = showCursor && (isTyping || (isPaused && showCursorOnPause)) && !disableTyping;
-
-      if (shouldShowCursorNow) {
-        // Use a unique marker that won't conflict with markdown syntax
-        // Using zero-width space to make it invisible if somehow rendered
-        return markdownString + '\u200B__MDTYPER_CURSOR__\u200B';
-      }
-      return markdownString;
-    }, [markdownString, showCursor, showCursorOnPause, disableTyping, updateCount]);
-
-    // Show cursor when typing is in progress (or paused based on config) and showCursor is enabled
-    // Must calculate after displayString to use same updateCount
     const shouldShowCursor = useMemo(() => {
       const isTyping = typingTask.isTypingRef.current;
       const hasPendingContent = charsRef.current.length > 0;
       const isPaused = !isTyping && hasPendingContent;
       return showCursor && (isTyping || (isPaused && showCursorOnPause)) && !disableTyping;
-    }, [showCursor, showCursorOnPause, disableTyping, updateCount]);
+    }, [showCursor, showCursorOnPause, disableTyping, updateCount, typingTask.isTypingRef]);
 
-    // Create rehype plugin to handle cursor placeholder
-    const rehypeCursorPlugin = useMemo(() => {
-      if (!shouldShowCursor) {
-        return null;
-      }
-      return createRehypeCursorPlugin(cursor);
-    }, [shouldShowCursor, cursor]);
-
-    // Merge rehype plugins
-    const mergedRehypePlugins = useMemo(() => {
-      const basePlugins = reactMarkdownProps?.rehypePlugins || [];
-      if (rehypeCursorPlugin) {
-        return [...basePlugins, rehypeCursorPlugin];
-      }
-      return basePlugins;
-    }, [reactMarkdownProps?.rehypePlugins, rehypeCursorPlugin]);
-
-    // Merge components
-    const mergedComponents = useMemo(() => {
+    const mergedComponentsWithCursor = useMemo(() => {
       if (!shouldShowCursor || typeof cursor === 'string') {
         return reactMarkdownProps?.components;
       }
 
-      // For ReactNode cursor, wrap span component to handle cursor placeholder
       return {
         ...reactMarkdownProps?.components,
         span: (props: any) => (
@@ -253,15 +460,53 @@ const MarkdownTyperCMD = forwardRef<MarkdownTyperCMDRef, MarkdownTyperCMDProps>(
       };
     }, [shouldShowCursor, cursor, reactMarkdownProps?.components]);
 
-    const mergedReactMarkdownProps = useMemo(() => {
+    const reactMarkdownPropsBase = useMemo(() => {
       return {
         ...reactMarkdownProps,
-        rehypePlugins: mergedRehypePlugins,
-        components: mergedComponents,
+        rehypePlugins: reactMarkdownProps?.rehypePlugins || [],
+        components: reactMarkdownProps?.components,
       };
-    }, [reactMarkdownProps, mergedRehypePlugins, mergedComponents]);
+    }, [reactMarkdownProps]);
 
-    return <ReactMarkdown {...mergedReactMarkdownProps}>{displayString}</ReactMarkdown>;
+    const reactMarkdownPropsWithCursor = useMemo(() => {
+      const basePlugins = reactMarkdownProps?.rehypePlugins || [];
+      return {
+        ...reactMarkdownProps,
+        rehypePlugins: [...basePlugins, createRehypeCursorPlugin(cursor)],
+        components: mergedComponentsWithCursor,
+      };
+    }, [reactMarkdownProps, cursor, mergedComponentsWithCursor]);
+
+    if (!experimentalIncrementalRender) {
+      const markdownString = customConvertMarkdownString?.(wholeContentRef.current.content) || wholeContentRef.current.content;
+      const displayString = shouldShowCursor ? `${markdownString}${CURSOR_MARKER}` : markdownString;
+      const mergedReactMarkdownProps = shouldShowCursor ? reactMarkdownPropsWithCursor : reactMarkdownPropsBase;
+      return <ReactMarkdown {...mergedReactMarkdownProps}>{displayString}</ReactMarkdown>;
+    }
+
+    const stableMarkdownString =
+      customConvertMarkdownString?.(stableContentRef.current) || stableContentRef.current;
+    let tailMarkdownString = customConvertMarkdownString?.(tailContentRef.current) || tailContentRef.current;
+
+    if (shouldShowCursor) {
+      tailMarkdownString = `${tailMarkdownString}${CURSOR_MARKER}`;
+    }
+
+    const hasStable = stableMarkdownString.length > 0;
+    const hasTail = tailMarkdownString.length > 0;
+
+    return (
+      <>
+        {hasStable && (
+          <ReactMarkdown {...reactMarkdownPropsBase}>{stableMarkdownString}</ReactMarkdown>
+        )}
+        {hasTail && (
+          <ReactMarkdown {...(shouldShowCursor ? reactMarkdownPropsWithCursor : reactMarkdownPropsBase)}>
+            {tailMarkdownString}
+          </ReactMarkdown>
+        )}
+      </>
+    );
   },
 );
 

--- a/src/defined.ts
+++ b/src/defined.ts
@@ -90,6 +90,15 @@ export interface MarkdownTyperBaseProps {
 
   /** Whether to show cursor when typing is paused, default is true */
   showCursorOnPause?: boolean;
+
+  /**
+   * Experimental incremental render mode.
+   * When enabled, the component avoids full markdown re-parse on every typed character.
+   */
+  experimentalIncrementalRender?: boolean;
+
+  /** Tail size threshold for incremental mode flush decisions. */
+  incrementalFlushThreshold?: number;
 }
 
 export interface MarkdownTyperProps extends MarkdownTyperBaseProps {
@@ -128,6 +137,8 @@ export type MarkdownTyperRef = MarkdownBaseRef;
 /** MarkdownCMD component ref type */
 export interface MarkdownTyperCMDRef extends MarkdownBaseRef {
   push: (content: string) => void;
+  /** Replace current rendered content immediately without typing animation. */
+  setContent: (content: string) => void;
   clear: () => void;
   triggerWholeEnd: () => void;
 }

--- a/src/hooks/useTypingTask.ts
+++ b/src/hooks/useTypingTask.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { IChar, ITypedChar, IWholeContent, MarkdownTyperProps, IEndData, IBeforeTypedChar, IntervalType } from '../defined';
+import { splitGraphemes } from '../utils/grapheme';
 
 interface UseTypingTaskOptions {
   timerType: MarkdownTyperProps['timerType'];
@@ -172,7 +173,7 @@ export const useTypingTask = (options: UseTypingTaskOptions): TypingTaskControll
     const allLength = wholeContentRef.current.length;
 
     // Calculate percentage of previous characters
-    const percent = (char.index / allLength) * 100;
+    const percent = allLength > 0 ? (char.index / allLength) * 100 : 0;
 
     await onBeforeTypedChar({
       currentIndex: index,
@@ -189,7 +190,7 @@ export const useTypingTask = (options: UseTypingTaskOptions): TypingTaskControll
     }
     const { content, index } = char;
     const allLength = wholeContentRef.current.length;
-    const percent = ((char.index + 1) / allLength) * 100;
+    const percent = allLength > 0 ? ((char.index + 1) / allLength) * 100 : 100;
 
     onTypedChar({
       currentIndex: index,
@@ -409,7 +410,7 @@ export const useTypingTask = (options: UseTypingTaskOptions): TypingTaskControll
     typedIsManualStopRef.current = false;
     // Put wholeContentRef content into charsRef
     charsRef.current.unshift(
-      ...wholeContentRef.current.content.split('').map((charUnit) => {
+      ...splitGraphemes(wholeContentRef.current.content).map((charUnit) => {
         const char: IChar = {
           content: charUnit,
           tokenId: 0,

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom';
+
+// React 18+ act environment flag for createRoot tests.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;

--- a/test/unit/typing-behavior.test.tsx
+++ b/test/unit/typing-behavior.test.tsx
@@ -1,0 +1,98 @@
+import { act, createRef } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { MarkdownTyper, MarkdownTyperCMD, MarkdownTyperCMDRef } from '../../src';
+
+function mount(element: React.ReactElement): { unmount: () => void } {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root;
+  act(() => {
+    root = createRoot(container);
+    root.render(element);
+  });
+  return {
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe('typing behavior', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('onBeforeTypedChar percent is finite for the first character', async () => {
+    jest.useFakeTimers();
+    const ref = createRef<MarkdownTyperCMDRef>();
+    const onBeforeTypedChar = jest.fn().mockResolvedValue(undefined);
+
+    mount(<MarkdownTyperCMD ref={ref} interval={1} onBeforeTypedChar={onBeforeTypedChar} />);
+
+    await act(async () => {
+      ref.current?.push('A');
+      await Promise.resolve();
+      await jest.runAllTimersAsync();
+      await Promise.resolve();
+    });
+
+    expect(onBeforeTypedChar).toHaveBeenCalled();
+    const firstPercent = onBeforeTypedChar.mock.calls[0][0]?.percent;
+    expect(Number.isFinite(firstPercent)).toBe(true);
+    expect(firstPercent).toBe(0);
+  });
+
+  test('disableTyping mode reports cumulative content in onEnd', () => {
+    const ref = createRef<MarkdownTyperCMDRef>();
+    const onEnd = jest.fn();
+
+    mount(<MarkdownTyperCMD ref={ref} interval={1} disableTyping onEnd={onEnd} />);
+
+    act(() => {
+      ref.current?.push('a');
+      ref.current?.push('b');
+    });
+
+    expect(onEnd).toHaveBeenCalledTimes(2);
+    expect(onEnd.mock.calls[0][0]?.str).toBe('a');
+    expect(onEnd.mock.calls[1][0]?.str).toBe('ab');
+  });
+
+  test('restart keeps grapheme clusters intact', async () => {
+    jest.useFakeTimers();
+    const ref = createRef<MarkdownTyperCMDRef>();
+    const onTypedChar = jest.fn();
+    const emoji = '👨‍👩‍👧‍👦';
+
+    mount(<MarkdownTyperCMD ref={ref} interval={1} onTypedChar={onTypedChar} />);
+
+    await act(async () => {
+      ref.current?.push(emoji);
+      await jest.runAllTimersAsync();
+      await Promise.resolve();
+    });
+
+    const firstRunChars = onTypedChar.mock.calls.map((call) => call[0]?.currentChar);
+    onTypedChar.mockClear();
+
+    await act(async () => {
+      ref.current?.restart();
+      await jest.runAllTimersAsync();
+      await Promise.resolve();
+    });
+
+    const secondRunChars = onTypedChar.mock.calls.map((call) => call[0]?.currentChar);
+    expect(secondRunChars).toEqual(firstRunChars);
+  });
+
+  test('MarkdownTyper does not log on unmount', () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const app = mount(<MarkdownTyper interval={1}>hello</MarkdownTyper>);
+    app.unmount();
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/typing-behavior.test.tsx
+++ b/test/unit/typing-behavior.test.tsx
@@ -2,7 +2,7 @@ import { act, createRef } from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { MarkdownTyper, MarkdownTyperCMD, MarkdownTyperCMDRef } from '../../src';
 
-function mount(element: React.ReactElement): { unmount: () => void } {
+function mount(element: React.ReactElement): { unmount: () => void; rerender: (next: React.ReactElement) => void; getText: () => string } {
   const container = document.createElement('div');
   document.body.appendChild(container);
   let root: Root;
@@ -11,6 +11,12 @@ function mount(element: React.ReactElement): { unmount: () => void } {
     root.render(element);
   });
   return {
+    rerender: (next) => {
+      act(() => {
+        root.render(next);
+      });
+    },
+    getText: () => container.textContent || '',
     unmount: () => {
       act(() => {
         root.unmount();
@@ -18,6 +24,10 @@ function mount(element: React.ReactElement): { unmount: () => void } {
       container.remove();
     },
   };
+}
+
+function stripWhitespace(value: string): string {
+  return value.replace(/\s+/g, '');
 }
 
 describe('typing behavior', () => {
@@ -94,5 +104,90 @@ describe('typing behavior', () => {
     const app = mount(<MarkdownTyper interval={1}>hello</MarkdownTyper>);
     app.unmount();
     expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  test('experimentalIncrementalRender handles prefix changes by typing only new suffix', async () => {
+    jest.useFakeTimers();
+    const onTypedChar = jest.fn();
+    const app = mount(
+      <MarkdownTyper interval={1} experimentalIncrementalRender onTypedChar={onTypedChar}>
+        abcde
+      </MarkdownTyper>,
+    );
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+      await Promise.resolve();
+    });
+
+    onTypedChar.mockClear();
+    app.rerender(
+      <MarkdownTyper interval={1} experimentalIncrementalRender onTypedChar={onTypedChar}>
+        abcXY
+      </MarkdownTyper>,
+    );
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+      await Promise.resolve();
+    });
+
+    const typed = onTypedChar.mock.calls.map((call) => call[0]?.currentChar).join('');
+    expect(typed).toBe('XY');
+    app.unmount();
+  });
+
+  test.each([
+    {
+      name: 'setext heading',
+      before: 'Title\n=====\n\nalpha',
+      after: 'Title\n=====\n\nbeta',
+      expectedTyped: 'beta',
+      expectedTextIncludes: 'beta',
+    },
+    {
+      name: 'gfm table',
+      before: '| col | val |\n| --- | --- |\n| a | 1 |\n',
+      after: '| col | val |\n| --- | --- |\n| a | 2 |\n',
+      expectedTyped: '2 |\n',
+      expectedTextIncludes: '2',
+    },
+    {
+      name: 'blockquote and list',
+      before: '> quoted line\n\n- item one\n- item two',
+      after: '> quoted line\n\n- item one\n- item three',
+      expectedTyped: 'hree',
+      expectedTextIncludes: 'item three',
+    },
+  ])('experimentalIncrementalRender keeps block integrity for $name', async ({ before, after, expectedTyped, expectedTextIncludes }) => {
+    jest.useFakeTimers();
+    const onTypedChar = jest.fn();
+    const app = mount(
+      <MarkdownTyper interval={1} experimentalIncrementalRender onTypedChar={onTypedChar}>
+        {before}
+      </MarkdownTyper>,
+    );
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+      await Promise.resolve();
+    });
+
+    onTypedChar.mockClear();
+    app.rerender(
+      <MarkdownTyper interval={1} experimentalIncrementalRender onTypedChar={onTypedChar}>
+        {after}
+      </MarkdownTyper>,
+    );
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+      await Promise.resolve();
+    });
+
+    const typed = onTypedChar.mock.calls.map((call) => call[0]?.currentChar).join('');
+    expect(typed).toBe(expectedTyped);
+    expect(stripWhitespace(app.getText())).toContain(stripWhitespace(expectedTextIncludes));
+    app.unmount();
   });
 });


### PR DESCRIPTION
**What**
Add `experimentalIncrementalRender` prop that splits rendered content into a **stable** part (rendered once) and a **tail** part (updated as characters are typed), reducing full markdown re-parses on every keystroke.

**Changes**
- `experimentalIncrementalRender` prop — opt-in incremental rendering
- `incrementalFlushThreshold` prop — controls tail buffer flush size (default 1200)
- `setContent()` ref method — replace content instantly without typing animation
- Block-boundary tracking (`IncrementalContext`) for fenced code, math, tables, blockquotes, setext headings — flushes tail only at safe boundaries
- LCP optimization: when content diverges mid-string, reuses the common prefix and only types the diff

**Notes**
- Off by default, no breaking changes
- `experimental` prefix signals API may change in future releases